### PR TITLE
Add test workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,36 @@
+name: Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  pytest:
+    name: Python ${{ matrix.python-version }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+
+      - name: Install package and test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e .
+          python -m pip install pytest xgboost lightgbm flaml
+
+      - name: Run tests
+        run: |
+          python -m pytest tests/test_kernel_explainer.py tests/test_tree_explainer.py -q

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install -e .
-          python -m pip install pytest xgboost lightgbm flaml
+          python -m pip install pytest matplotlib xgboost lightgbm flaml
 
       - name: Run tests
         run: |


### PR DESCRIPTION
## Summary
- add a GitHub Actions test workflow for pushes and pull requests to main
- run the focused Kernel and tree GeoShapley test suites on Python 3.10, 3.11, and 3.12
- install optional tree integrations used by the tests: xgboost, lightgbm, and flaml

## Tests
- python -m pytest tests/test_kernel_explainer.py tests/test_tree_explainer.py -q